### PR TITLE
Save cookie

### DIFF
--- a/R/downloading.R
+++ b/R/downloading.R
@@ -37,8 +37,9 @@
 #' get_file(1, 87, data_type = 'extraction')
 #' }
 
-get_file <- function(file = NULL, project = NULL, url = NULL,
-                     data_type = c(NA, 'extraction', 'project'), ...){
+get_file <- function(file = NULL, project = NULL,
+                     data_type = c(NA, 'extraction', 'project'),
+                     url = NULL, ...){
 
   # This function will do the downloading once we have a URL.
   download_process <- function(url){
@@ -61,6 +62,8 @@ get_file <- function(file = NULL, project = NULL, url = NULL,
 
 # If calling the URL directly:
   if(!is.null(url)){
+
+    login_check(url)
 
     download_process(url = url)
 
@@ -94,6 +97,7 @@ get_file <- function(file = NULL, project = NULL, url = NULL,
       project <- get_project_number(project)
     }
 
+    # As well as getting the file list, this will call login_check() to check credentials
     file_html <- get_file_list(project, data_type)
 
     file_table <- html_table_to_df(file_html)
@@ -127,6 +131,7 @@ get_file <- function(file = NULL, project = NULL, url = NULL,
 
   }
 }
+
 
 
 #' Search for tags on the MATOS website
@@ -185,3 +190,8 @@ tag_search <- function(tags, start_date, end_date, import = F){
     cat('\nCompleted!')
   }
 }
+
+
+# OTN deployment data template
+
+# OTN tagging data template

--- a/R/listing.R
+++ b/R/listing.R
@@ -10,9 +10,11 @@
 #' get_my_projects()
 #' }
 get_my_projects <- function(){
-  site <- httr::GET(
-    'https://matos.asascience.com/report/submit'
-  )
+  url <- 'https://matos.asascience.com/report/submit'
+
+  login_check(url)
+
+  site <- httr::GET(url)
 
   names <- httr::content(site) %>%
     rvest::html_node(xpath = '//*[@id="selProject"]') %>%
@@ -83,6 +85,7 @@ list_files <- function(project = NULL, data_type = c('extraction', 'project')){
   }
 
   # Scrape table and list files
+  # This calls login_check() under the hood
   files_html <- get_file_list(project, data_type = data_type)
 
   files <- html_table_to_df(files_html)

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -70,6 +70,9 @@ matos_login <- function(){
 #' \code{html_table_to_df} converts the HTML table provided by \code{get_file_list}
 #' into a R-usable data frame.
 #'
+#' \code{login_check} pings protected URLs and calls \code{matos_login} when referred
+#' to the login page.
+#'
 #' \code{scrape_file_urls} is used internally by \code{html_table_to_df} to extract
 #' the URLs associates with each "Download" link.
 #'
@@ -78,6 +81,7 @@ matos_login <- function(){
 #' @param project Character string of the full MATOS project name. This will be the
 #' big name in bold at the top of your project page, not the "Project Title" below it.
 #' Will be coerced to all lower case, so capitalization doesn't matter.
+#' @param url The (protected) URL that the overlapping function is trying to call.
 #' @param html_file_list Listed files in HTML form. Always the result of
 #' \code{get_file_list}
 #'
@@ -85,11 +89,14 @@ matos_login <- function(){
 #' @name utilities
 
 get_file_list <- function(project_number, data_type){
-  httr::GET(
-    paste('https://matos.asascience.com/project',
-          data_type,
-          project_number, sep = '/')
-  )
+
+  url <- paste('https://matos.asascience.com/project',
+               data_type,
+               project_number, sep = '/')
+
+  login_check(url)
+
+  httr::GET(url)
 }
 
 
@@ -120,7 +127,13 @@ html_table_to_df <- function(html_file_list){
 #' @rdname utilities
 #'
 login_check <- function(url){
-  httr::HEAD(url)
+  check_response <- httr::HEAD(url)
+
+  if(nrow(check_response$cookies) == 1){
+    message('Please log in.')
+
+    matos_login()
+  }
 
 }
 

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -20,13 +20,18 @@
 #' }
 
 matos_login <- function(){
+  credentials <- list(
+    UserName = rstudioapi::showPrompt(
+      title = "Username", message = "Please enter username.", default = ""
+    ),
+    Password = rstudioapi::askForPassword('Please enter password.')
+  )
+
+
   login_response <- httr::POST(
     'https://matos.asascience.com/account/login',
-    body = list(
-      UserName = rstudioapi::showPrompt(
-        title = "Username", message = "Please enter username.", default = ""),
-      Password = rstudioapi::askForPassword('Please enter password.')
-    )
+    body = credentials,
+    encode = 'form'
   )
 
   if(grepl('login', login_response)){
@@ -111,6 +116,13 @@ html_table_to_df <- function(html_file_list){
   cbind(df, url = urls)
 }
 
+
+#' @rdname utilities
+#'
+login_check <- function(url){
+  httr::HEAD(url)
+
+}
 
 #' @rdname utilities
 #'

--- a/man/get_file.Rd
+++ b/man/get_file.Rd
@@ -7,8 +7,8 @@
 get_file(
   file = NULL,
   project = NULL,
-  url = NULL,
   data_type = c(NA, "extraction", "project"),
+  url = NULL,
   ...
 )
 }
@@ -19,8 +19,6 @@ the index as found from \code{list_files}.}
 \item{project}{A character vector listing the full name of the project, or a
 numeric listing the project number.}
 
-\item{url}{The URL of the file to be downloaded.}
-
 \item{data_type}{one of NA (default), "extraction", or "project"; used in a
 call to \code{list_files} under the hood. If NA, it will try to guess whether
 project files or data extraction files are desired from the file name. If
@@ -28,6 +26,8 @@ the file index is provided, it cannot guess and will throw an error. When
 "extraction" or "project" is provided, it will list the data extraction or
 project files, respectively. Partial matching is allowed, and will repair
 to the correct argument if spaces or the words "data"/"file(s)" are included.}
+
+\item{url}{The URL of the file to be downloaded.}
 
 \item{...}{Arguments passed to httr::write_disk.}
 }

--- a/man/utilities.Rd
+++ b/man/utilities.Rd
@@ -5,6 +5,7 @@
 \alias{get_file_list}
 \alias{get_project_number}
 \alias{html_table_to_df}
+\alias{login_check}
 \alias{scrape_file_urls}
 \title{Create new MATOS project}
 \usage{
@@ -13,6 +14,8 @@ get_file_list(project_number, data_type)
 get_project_number(project)
 
 html_table_to_df(html_file_list)
+
+login_check(url)
 
 scrape_file_urls(html_file_list)
 }
@@ -27,6 +30,8 @@ Will be coerced to all lower case, so capitalization doesn't matter.}
 
 \item{html_file_list}{Listed files in HTML form. Always the result of
 \code{get_file_list}}
+
+\item{url}{The (protected) URL that the overlapping function is trying to call.}
 }
 \description{
 Somewhat useless function that just opens up the MATOS project creation page
@@ -45,6 +50,9 @@ project by scraping the HTML of the main MATOS projects page.
 
 \code{html_table_to_df} converts the HTML table provided by \code{get_file_list}
 into a R-usable data frame.
+
+\code{login_check} pings protected URLs and calls \code{matos_login} when referred
+to the login page.
 
 \code{scrape_file_urls} is used internally by \code{html_table_to_df} to extract
 the URLs associates with each "Download" link.


### PR DESCRIPTION
Can't quite figure out how to save the cookies, *per se*, and I don't think that {httr} wants you to do that anyway ([following the `httr::handle` docs](https://httr.r-lib.org/reference/handle.html)). The solution here was, before accessing protected info, to check if the user is referred to the login page via a call to `HEAD`. If so, login is prompted.

Closes #1.